### PR TITLE
Add support for custom resolution

### DIFF
--- a/src/assets/styles/partials/_guide.scss
+++ b/src/assets/styles/partials/_guide.scss
@@ -79,7 +79,7 @@
 
 }
 @media only screen and (min-height: 950px) {
-    .guide-content.dt { height: 800px; }
+    .guide-content.dt { height: 80vh; }
 }
 @media only screen and (max-height: 949px) {
     .guide-content.dt { height: calc(100vh - 15px); }

--- a/src/assets/styles/partials/_mainContainer.scss
+++ b/src/assets/styles/partials/_mainContainer.scss
@@ -15,6 +15,16 @@
             background-color: $scrollbar-thumb;
         }
     }
+
+    &:not(.mb) {
+        display: grid;
+        grid-auto-flow: row dense;
+        grid-auto-columns: 1fr;
+        grid-auto-rows: 1fr;
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+        gap: 0px 8px;
+        justify-content: center;
+    }
 }
 .banner {
     @include padding;

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -219,10 +219,10 @@ function setAnimAndPos(): void {
 	// guide animations and close/gototop button positions
 	if (deviceHeight >= 950) {
 		[guideEntryAnim, guideExitAnim] = ['guide-entry-desktop-n', 'guide-exit-desktop-n'];
-		[topPos, bottomPos] = [135, 866];
+		[topPos, bottomPos] = [deviceHeight * 0.13, deviceHeight * 0.87];
 	} else {
 		[guideEntryAnim, guideExitAnim] = ['guide-entry-desktop-s', 'guide-exit-desktop-s'];
-		[topPos, bottomPos] = [15, deviceHeight - 60];
+		[topPos, bottomPos] = [deviceHeight * 0.03, deviceHeight * 0.87];
 	}
 }
 


### PR DESCRIPTION
Hello,
I resolved some issues with custom resolution also changed some styles, so banners can be displayed depending on monitor `width` without `limitations` or `requirement to show scroll`.

I used for it `grid` styles, plus a little change for `close` & `moveToTop` button to display it correctly.
These changes will apply only to the PC version of the site.

<details>
<summary>Screenshots</summary>

### Before update:

1. ![2023-04-11_144524](https://user-images.githubusercontent.com/130451275/231153232-e38cb4af-fb5e-422f-85bc-fb06060b3854.jpg)
2. ![image](https://user-images.githubusercontent.com/130451275/231165522-d3331710-1b7a-40a0-863e-78be355427fb.png)
3. ![2023-04-11_144701](https://user-images.githubusercontent.com/130451275/231153517-57bd80f3-eb17-4fb4-9c13-4cc510f38197.jpg)

### After Update:

1. ![2023-04-11_150258](https://user-images.githubusercontent.com/130451275/231156931-0a19bbf1-dc73-49f5-b5ce-b4ada54b393d.jpg)
2. ![2023-04-11_150322](https://user-images.githubusercontent.com/130451275/231157033-450f6c18-70e0-4cb0-914c-52d27eca2209.jpg)
3. ![2023-04-11_150437](https://user-images.githubusercontent.com/130451275/231157246-a91b7bd2-2b45-4fe8-b49a-2bd1beb9cf0e.jpg)

</details>